### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/nyurik/osm-node-cache/compare/v0.10.0...v0.10.1) - 2025-10-01
+
+### Other
+
+- use automatic crates.io token
+- restore osmpbf to dev deps
+- add more linting
+- *(just)* minor justfile cleanup
+- *(ci)* improve cargo-install recipe
+- improve ci and justfile ([#31](https://github.com/nyurik/osm-node-cache/pull/31))
+- [pre-commit.ci] pre-commit autoupdate ([#29](https://github.com/nyurik/osm-node-cache/pull/29))
+- use release-plz token in dependabot ci
+
 ## [0.10.0](https://github.com/nyurik/osm-node-cache/compare/v0.9.0...v0.10.0) - 2025-06-08
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmnodecache"
-version = "0.10.0"
+version = "0.10.1"
 description = "Flat file OSM node cache to store (latitude,longitude) pairs as indexed entries"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/osm-node-cache"


### PR DESCRIPTION



## 🤖 New release

* `osmnodecache`: 0.10.0 -> 0.10.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.1](https://github.com/nyurik/osm-node-cache/compare/v0.10.0...v0.10.1) - 2025-10-01

### Other

- use automatic crates.io token
- restore osmpbf to dev deps
- add more linting
- *(just)* minor justfile cleanup
- *(ci)* improve cargo-install recipe
- improve ci and justfile ([#31](https://github.com/nyurik/osm-node-cache/pull/31))
- [pre-commit.ci] pre-commit autoupdate ([#29](https://github.com/nyurik/osm-node-cache/pull/29))
- use release-plz token in dependabot ci
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).