### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/nyurik/osm-node-cache/compare/v0.10.1...v0.10.2) - 2026-06-23
+
+### Other
+
+- update to manintained bincode ([#38](https://github.com/nyurik/osm-node-cache/pull/38))
+- update proj framework ([#36](https://github.com/nyurik/osm-node-cache/pull/36))
+- add .editorconfig
+- minor justfile adjustments
+- Bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#32](https://github.com/nyurik/osm-node-cache/pull/32))
+- minor justfile adjustments
+
 ## [0.10.1](https://github.com/nyurik/osm-node-cache/compare/v0.10.0...v0.10.1) - 2025-10-01
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmnodecache"
-version = "0.10.1"
+version = "0.10.2"
 description = "Flat file OSM node cache to store (latitude,longitude) pairs as indexed entries"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/osm-node-cache"


### PR DESCRIPTION



## 🤖 New release

* `osmnodecache`: 0.10.1 -> 0.10.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.2](https://github.com/nyurik/osm-node-cache/compare/v0.10.1...v0.10.2) - 2026-06-23

### Other

- update to manintained bincode ([#38](https://github.com/nyurik/osm-node-cache/pull/38))
- update proj framework ([#36](https://github.com/nyurik/osm-node-cache/pull/36))
- add .editorconfig
- minor justfile adjustments
- Bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#32](https://github.com/nyurik/osm-node-cache/pull/32))
- minor justfile adjustments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).