### PR TITLE
chore: release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/nyurik/osm-node-cache/compare/v0.10.2...v0.10.3) - 2026-07-14
+
+### Other
+
+- fix justfile cargo binstall
+- let rust fmt indent .rs files
+- disallow mem leaking in code
+- fix unset in justfile
+- ignore CARGO_BUILD_WARNINGS in cargo-install
+- use Rust 1.97 cargo warnings
+
 ## [0.10.2](https://github.com/nyurik/osm-node-cache/compare/v0.10.1...v0.10.2) - 2026-06-23
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmnodecache"
-version = "0.10.2"
+version = "0.10.3"
 description = "Flat file OSM node cache to store (latitude,longitude) pairs as indexed entries"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/osm-node-cache"


### PR DESCRIPTION



## 🤖 New release

* `osmnodecache`: 0.10.2 -> 0.10.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.3](https://github.com/nyurik/osm-node-cache/compare/v0.10.2...v0.10.3) - 2026-07-14

### Other

- fix justfile cargo binstall
- let rust fmt indent .rs files
- disallow mem leaking in code
- fix unset in justfile
- ignore CARGO_BUILD_WARNINGS in cargo-install
- use Rust 1.97 cargo warnings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).